### PR TITLE
macOS fixes

### DIFF
--- a/install.go
+++ b/install.go
@@ -71,7 +71,7 @@ func createDir(path string) error {
 		return err
 	}
 	if !pathExists {
-		err := os.Mkdir(path, 0644)
+		err := os.Mkdir(path, 0700)
 		if err != nil {
 			return err
 		}

--- a/ui.go
+++ b/ui.go
@@ -125,7 +125,7 @@ func getProfilePaths() []string {
 		iniPath = homedir + "\\AppData\\Roaming\\Mozilla\\Firefox\\profiles.ini"
 
 	case "darwin":
-		iniPath = homedir + "/Library/Mozilla/profiles.ini"
+		iniPath = homedir + "/Library/Application Support/Firefox/profiles.ini"
 
 	case "linux":
 		iniPath = homedir + "/.mozilla/profiles.ini"


### PR DESCRIPTION
* Changed directory location for `profiles.ini`

* Changed permissions when creating directories.  0700 was the only option I found on macOS that properly allowed read/write.  Others were creating "custom" permissions that you would have to enter you password to open (therefore preventing the script from being able to run as well).  